### PR TITLE
HC-373: override consumer_timeout default value from 15 minutes to 1 week

### DIFF
--- a/templates/rabbitmq.config
+++ b/templates/rabbitmq.config
@@ -8,6 +8,7 @@
     [
       { loopback_users, [] },
       { vm_memory_high_watermark, 1 },
+      { consumer_timeout, 6040800000 },
       { tcp_listen_options, [
                               { backlog, 102400 },
                               { nodelay, true },


### PR DESCRIPTION
Tested in NISAR. No longer see errors relating to time outs.