### PR TITLE
HC-522-update: Updates to support moving away from the OPS user in the Core containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
+ARG TAG=HC-522
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522
+ARG TAG=HC-522-update
 FROM hysds/dev:${TAG}
 
 # get org and branch
@@ -19,7 +19,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-mozart/git/refs/heads/${BRANCH} v
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
+ && sudo chown root:root $HOME/.git_oauth_token \
  && set -ex \
  && sudo dnf update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
@@ -60,19 +60,19 @@ RUN set -ex \
  && sudo rm -f /tmp/install.sh \
  && sudo rm -rf /var/cache/dnf
 
-# copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
+# copy root
+COPY --chown=root:root --from=0 /root /root
 
 # link configs
 RUN set -ex \
- && ln -sf /home/ops/mozart/etc/celeryconfig.py /home/ops/mozart/ops/hysds/celeryconfig.py \
- && ln -sf /home/ops/mozart/etc/settings.cfg /home/ops/mozart/ops/mozart/settings.cfg \
- && ln -sf /home/ops/mozart/etc/server.key /home/ops/mozart/ops/mozart/server.key \
- && ln -sf /home/ops/mozart/etc/server.pem /home/ops/mozart/ops/mozart/server.pem
+ && ln -sf /root/mozart/etc/celeryconfig.py /root/mozart/ops/hysds/celeryconfig.py \
+ && ln -sf /root/mozart/etc/settings.cfg /root/mozart/ops/mozart/settings.cfg \
+ && ln -sf /root/mozart/etc/server.key /root/mozart/ops/mozart/server.key \
+ && ln -sf /root/mozart/etc/server.pem /root/mozart/ops/mozart/server.pem
 
 # set default supervisord conf and copy includes
-COPY --chown=ops:ops docker/supervisord.conf /home/ops/mozart/etc/supervisord.conf
-COPY --chown=ops:ops docker/conf.d /home/ops/mozart/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf /root/mozart/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d /root/mozart/etc/conf.d
 
 # set entrypoint
 COPY docker/wait-for-it.sh /wait-for-it.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-mozart/git/refs/heads/${BRANCH} version.json
 
-# set HOME explicitly
-ENV HOME /home/ops
-
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,9 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-mozart/git/refs/heads/${BRANCH} version.json
 
+# set HOME explicitly
+ENV HOME /home/ops
+
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # set HOME explicitly
-export HOME=/home/ops
+export HOME=/root
 
 # wait for rabbitmq, redis, and ES
 /wait-for-it.sh -t 30 mozart-rabbitmq:15672
@@ -16,14 +16,14 @@ GID=$(id -g)
 gosu 0:0 ssh-keygen -A 2>/dev/null
 
 # update user and group ids
-gosu 0:0 groupmod -g $GID ops 2>/dev/null
-gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-gosu 0:0 usermod -aG docker ops 2>/dev/null
+#gosu 0:0 groupmod -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -aG docker ops 2>/dev/null
 
 # update ownership
-gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
 
 # source bash profile
 source $HOME/.bash_profile

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -15,15 +15,9 @@ GID=$(id -g)
 # generate ssh keys
 gosu 0:0 ssh-keygen -A 2>/dev/null
 
-# update user and group ids
-#gosu 0:0 groupmod -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -aG docker ops 2>/dev/null
-
-# update ownership
-#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+if [ -e /var/run/docker.sock ]; then
+  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+fi
 
 # source bash profile
 source $HOME/.bash_profile

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class mozart inherits hysds_base {
   # copy user files
   #####################################################
   
-  file { "/home/$user/.bash_profile":
+  file { "/$user/.bash_profile":
     ensure  => present,
     content => template('mozart/bash_profile'),
     owner   => $user,
@@ -22,7 +22,7 @@ class mozart inherits hysds_base {
   # mozart directory
   #####################################################
 
-  $mozart_dir = "/home/$user/mozart"
+  $mozart_dir = "/$user/mozart"
 
 
   #####################################################
@@ -88,7 +88,7 @@ class mozart inherits hysds_base {
   # files in ops home
   #####################################################
 
-  file { "/home/$user/install_hysds.sh":
+  file { "/$user/install_hysds.sh":
     ensure  => present,
     content => template('mozart/install_hysds.sh'),
     owner   => $user,
@@ -148,7 +148,7 @@ class mozart inherits hysds_base {
 
 
   mozart::tarball { "logstash-7.9.3.tar.gz":
-    install_dir => "/home/$user",
+    install_dir => "/$user",
     owner => $user,
     group => $group,
     require => [
@@ -158,9 +158,9 @@ class mozart inherits hysds_base {
   }
 
 
-  file { "/home/$user/logstash":
+  file { "/$user/logstash":
     ensure => 'link',
-    target => "/home/$user/logstash-7.9.3",
+    target => "/$user/logstash-7.9.3",
     owner => $user,
     group => $group,
     require => Mozart::Tarball['logstash-7.9.3.tar.gz'],


### PR DESCRIPTION
This PR updates the Dockerfile, entrypoint scripts, and Puppet Manifest files such that it supports the moving away from the OPS user that the Core containers would default to.

CircleCI passed when building containers under the HC-522-update tag:

![image](https://github.com/user-attachments/assets/2154a661-b3cb-4505-91e5-8506c4a28349)

Will need to remove the following kludges before merging:

- https://github.com/hysds/puppet-mozart/compare/docker...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR2